### PR TITLE
Remove the need for custom Babel configuration

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,6 +6,10 @@ exports.onCreateWebpackConfig = ({ actions, getConfig, rules, stage }) => {
     loader: 'linaria/loader',
     options: {
       sourceMap: stage.includes('develop'),
+      displayName: stage.includes('develop'),
+      babelOptions: {
+        presets: ['babel-preset-gatsby'],
+      },
     },
   }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "gatsby": ">=2",
-    "linaria": ">=1.0.0-beta"
+    "linaria": ">=1.2.0"
   },
   "devDependencies": {
     "eslint": "^5.11.1",

--- a/readme.md
+++ b/readme.md
@@ -2,12 +2,6 @@
 
 This plugin modifies Gatsby's webpack configuration to support [Linaria][].
 
----
-
-**Note**: You still need to set up Babel configuration manually. More information at the bottom.
-
----
-
 Install the plugin and Linaria:
 
 ```sh
@@ -22,31 +16,11 @@ plugins: [
 ]
 ```
 
-## Babel configuration file
+Finally, make sure to add `.linaria-cache` to your `.gitignore` file.
 
-Currently, gatsby-plugin-linaria also requires setting up a [custom Babel configuration file][custom-babel-config] to your Gatsby project in order for Linaria to be able to pick it up. I hope to eliminate this requirement in the future.
-
-```
-yarn add babel-preset-gatsby
-```
-
-```js
-// babel.config.js
-module.exports = {
-  presets: [
-    'babel-preset-gatsby',
-    ['linaria/babel', {
-      evaluate: true,
-      displayName: process.env.NODE_ENV !== 'production',
-    }],
-  ],
-}
-```
-
-Also, make sure to add `.linaria-cache` to your `.gitignore` file.
+That's it! gatsby-plugin-linaria configures Linaria's webpack plugin to use [babel-preset-gatsby][], which contains Gatsby's Babel configuration.
 
 Happy styling! :art:
 
 [Linaria]: https://github.com/callstack/linaria
-[custom-babel-config]: https://www.gatsbyjs.org/docs/babel/#how-to-use-a-custom-babelrc-file
-[Babel preset]: https://github.com/callstack/linaria/blob/master/docs/BABEL_PRESET.md
+[babel-preset-gatsby]: https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby


### PR DESCRIPTION
By adding [babel-preset-gatsby](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby) to Linaria's `babelOptions`, we no longer
need to add a custom Babel configuration to our Gatsby project in order
for Linaria to work.

Fixes #6.