### PR TITLE
Fix missing extract on site using context path

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { collect } from 'linaria/server'
 
-const LINARIA_STYLESHEET_RULE = /^\/linaria\.[\w\d]+\.css$/
+const LINARIA_STYLESHEET_RULE = /\/linaria\.[\w\d]+\.css$/
 
 let bodyHTML
 


### PR DESCRIPTION
Hey @silvenon, I just found a bug I made

`LINARIA_STYLESHEET_RULE` did not match when site use context path. e.g: `/crjp/linaria.dfec037c6e09819cc13b.css`

so, fixed the regex.